### PR TITLE
chore: release v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.3.0](https://github.com/eRgo35/ti/releases/tag/v1.3.0) - 2024-08-13
+
+### Added
+- positional argument for time
+- timer is multithreaded
+
+### Fixed
+- README.me
+- moved font to resources
+- ux improvements
+- refactor timer initialization
+- refactor
+- optmize
+
+### Other
+- release-plz setup
+- cargo-dist action setup
+- release 1.3.0
+- release 1.2.3
+- github actions: init
+- 1.2.2
+- 1.2.1
+- moved drawing to separate mod
+- 1.2.0
+- 1.1.2
+- version bump
+- 1.1.1 more functional
+- 1.1.0 added documentation, fixed pathing and fonts
+- initial release 1.0.0


### PR DESCRIPTION
## 🤖 New release
* `ti`: 1.3.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.3.0](https://github.com/eRgo35/ti/releases/tag/v1.3.0) - 2024-08-13

### Added
- positional argument for time
- timer is multithreaded

### Fixed
- README.me
- moved font to resources
- ux improvements
- refactor timer initialization
- refactor
- optmize

### Other
- release-plz setup
- cargo-dist action setup
- release 1.3.0
- release 1.2.3
- github actions: init
- 1.2.2
- 1.2.1
- moved drawing to separate mod
- 1.2.0
- 1.1.2
- version bump
- 1.1.1 more functional
- 1.1.0 added documentation, fixed pathing and fonts
- initial release 1.0.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).