### PR TITLE
chore: release v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.1](https://github.com/eRgo35/ti/compare/v1.3.0...v1.3.1) - 2024-08-13
+
+### Other
+- release
+
 ## [1.3.0](https://github.com/eRgo35/ti/releases/tag/v1.3.0) - 2024-08-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "ti"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "clap",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ti"
-version = "1.3.0"
+version = "1.3.1"
 authors = ["Michał Czyż <mike@c2yz.com>"]
 edition = "2021"
 


### PR DESCRIPTION
## 🤖 New release
* `ti`: 1.3.0 -> 1.3.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.3.1](https://github.com/eRgo35/ti/compare/v1.3.0...v1.3.1) - 2024-08-13

### Other
- release
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).